### PR TITLE
Binding site refactor

### DIFF
--- a/plugin/SuperimposePlugin.py
+++ b/plugin/SuperimposePlugin.py
@@ -158,7 +158,7 @@ class SuperimposePlugin(nanome.AsyncPluginInstance):
         for moving_comp in moving_comp_list:
             ComplexUtils.align_to(moving_comp, fixed_comp)
 
-        superimpose_data = superimpose_by_binding_site(fixed_comp, moving_comp_list, fixed_binding_site_comp, self)
+        superimpose_data = await superimpose_by_binding_site(fixed_comp, moving_comp_list, fixed_binding_site_comp, self)
         fixed_binding_site_pdb.close()
         self.update_submit_btn_text('Updating Workspace...')
         for comp_index, data in superimpose_data.items():

--- a/plugin/SuperimposePlugin.py
+++ b/plugin/SuperimposePlugin.py
@@ -141,7 +141,7 @@ class SuperimposePlugin(nanome.AsyncPluginInstance):
         updated_complexes = await self.request_complexes([fixed_index, *moving_indices])
         fixed_comp = updated_complexes[0]
         moving_comp_list = updated_complexes[1:]
-        fixed_binding_site_residues = await self.get_binding_site_residues(fixed_comp, ligand_name, site_size)
+        fixed_binding_site_residues = await self.get_binding_site_residues(fixed_comp, ligand_index, site_size)
         
         # Select all atoms in the fixed binding site
         for atom in itertools.chain(*[res.atoms for res in fixed_binding_site_residues]):
@@ -188,7 +188,7 @@ class SuperimposePlugin(nanome.AsyncPluginInstance):
                 self.complexes[i] = updated_comp
         return rmsd_results
 
-    async def get_binding_site_residues(self, target_reference: Complex, ligand_index: int):
+    async def get_binding_site_residues(self, target_reference: Complex, ligand_index: int, site_size=5):
         """Identify atoms in the active site around a ligand."""
         mol = next(
             mol for i, mol in enumerate(target_reference.molecules)
@@ -196,7 +196,7 @@ class SuperimposePlugin(nanome.AsyncPluginInstance):
         target_ligands = await mol.get_ligands()
         ligand = target_ligands[ligand_index]
         ligand_atoms = itertools.chain(*[res.atoms for res in ligand.residues])
-        binding_site_atoms = utils.calculate_binding_site_atoms(target_reference, ligand_atoms)
+        binding_site_atoms = utils.calculate_binding_site_atoms(target_reference, ligand_atoms, site_size)
         residue_set = set()
         for atom in binding_site_atoms:
             residue_set.add(atom.residue)

--- a/plugin/SuperimposePlugin.py
+++ b/plugin/SuperimposePlugin.py
@@ -1,7 +1,7 @@
 import nanome
 import os
 import tempfile
-from itertools import chain
+import itertools
 from nanome.util import Logs, async_callback, ComplexUtils
 from nanome.api.structure import Complex
 from nanome.util import enums
@@ -144,7 +144,7 @@ class SuperimposePlugin(nanome.AsyncPluginInstance):
         fixed_binding_site_residues = await self.get_binding_site_residues(fixed_comp, ligand_name, site_size)
         
         # Select all atoms in the fixed binding site
-        for atom in chain(*[res.atoms for res in fixed_binding_site_residues]):
+        for atom in itertools.chain(*[res.atoms for res in fixed_binding_site_residues]):
             atom.selected = True
 
         fixed_binding_site_comp = utils.extract_binding_site(fixed_comp, fixed_binding_site_residues)
@@ -195,7 +195,7 @@ class SuperimposePlugin(nanome.AsyncPluginInstance):
             if i == target_reference.current_frame)
         target_ligands = await mol.get_ligands()
         ligand = next(ligand for ligand in target_ligands if ligand.name == ligand_name)
-        ligand_atoms = chain(*[res.atoms for res in ligand.residues])
+        ligand_atoms = itertools.chain(*[res.atoms for res in ligand.residues])
         binding_site_atoms = utils.calculate_binding_site_atoms(target_reference, ligand_atoms)
         residue_set = set()
         for atom in binding_site_atoms:

--- a/plugin/SuperimposePlugin.py
+++ b/plugin/SuperimposePlugin.py
@@ -141,8 +141,12 @@ class SuperimposePlugin(nanome.AsyncPluginInstance):
         updated_complexes = await self.request_complexes([fixed_index, *moving_indices])
         fixed_comp = updated_complexes[0]
         moving_comp_list = updated_complexes[1:]
-        # Select the binding site on the fixed complex.
         fixed_binding_site_residues = await self.get_binding_site_residues(fixed_comp, ligand_name, site_size)
+        
+        # Select all atoms in the fixed binding site
+        for atom in chain(*[res.atoms for res in fixed_binding_site_residues]):
+            atom.selected = True
+
         fixed_binding_site_comp = utils.extract_binding_site(fixed_comp, fixed_binding_site_residues)
         fixed_binding_site_pdb = tempfile.NamedTemporaryFile(dir=self.temp_dir.name, suffix='.pdb')
         fixed_binding_site_comp.io.to_pdb(path=fixed_binding_site_pdb.name)

--- a/plugin/SuperimposePlugin.py
+++ b/plugin/SuperimposePlugin.py
@@ -154,8 +154,9 @@ class SuperimposePlugin(nanome.AsyncPluginInstance):
         for moving_comp in moving_comp_list:
             ComplexUtils.align_to(moving_comp, fixed_comp)
 
-        superimpose_data = superimpose_by_binding_site(fixed_comp, moving_comp_list, fixed_binding_site_comp)
+        superimpose_data = superimpose_by_binding_site(fixed_comp, moving_comp_list, fixed_binding_site_comp, self)
         fixed_binding_site_pdb.close()
+        self.update_submit_btn_text('Updating Workspace...')
         for comp_index, data in superimpose_data.items():
             moving_comp = next(comp for comp in moving_comp_list if comp.index == comp_index)
             transform_matrix, rmsd_data = data
@@ -200,6 +201,9 @@ class SuperimposePlugin(nanome.AsyncPluginInstance):
     def update_loading_bar(self, current, total):
         self.menu.update_loading_bar(current, total)
 
+    def update_submit_btn_text(self, new_text):
+        if getattr(self, 'menu', None):
+            self.menu.update_submit_btn_text(new_text)
 
 def main():
     plugin_title = 'Superimpose Proteins'

--- a/plugin/SuperimposePlugin.py
+++ b/plugin/SuperimposePlugin.py
@@ -137,7 +137,7 @@ class SuperimposePlugin(nanome.AsyncPluginInstance):
         return rmsd_results
 
     async def superimpose_by_binding_site(
-            self, fixed_index: int, ligand_name: str, moving_indices: list, site_size=5):
+            self, fixed_index: int, ligand_index: int, moving_indices: list, site_size=5):
         updated_complexes = await self.request_complexes([fixed_index, *moving_indices])
         fixed_comp = updated_complexes[0]
         moving_comp_list = updated_complexes[1:]
@@ -188,13 +188,13 @@ class SuperimposePlugin(nanome.AsyncPluginInstance):
                 self.complexes[i] = updated_comp
         return rmsd_results
 
-    async def get_binding_site_residues(self, target_reference: Complex, ligand_name: str, site_size=4.5):
+    async def get_binding_site_residues(self, target_reference: Complex, ligand_index: int):
         """Identify atoms in the active site around a ligand."""
         mol = next(
             mol for i, mol in enumerate(target_reference.molecules)
             if i == target_reference.current_frame)
         target_ligands = await mol.get_ligands()
-        ligand = next(ligand for ligand in target_ligands if ligand.name == ligand_name)
+        ligand = target_ligands[ligand_index]
         ligand_atoms = itertools.chain(*[res.atoms for res in ligand.residues])
         binding_site_atoms = utils.calculate_binding_site_atoms(target_reference, ligand_atoms)
         residue_set = set()

--- a/plugin/SuperimposePlugin.py
+++ b/plugin/SuperimposePlugin.py
@@ -174,7 +174,8 @@ class SuperimposePlugin(nanome.AsyncPluginInstance):
             moving_comp.set_surface_needs_redraw()
             comps_to_update.append(moving_comp)
         
-        await self.update_structures_deep(comps_to_update)
+        self.update_structures_shallow(comps_to_update)
+        self.update_structures_shallow(itertools.chain(*[comp.atoms for comp in comps_to_update]))
         # Due to a bug in nanome-core, if a complex is unlocked, we need to
         # make a second call to remove box from around complexes.
         self.update_structures_shallow(comps_to_update)

--- a/plugin/SuperimposePlugin.py
+++ b/plugin/SuperimposePlugin.py
@@ -142,7 +142,7 @@ class SuperimposePlugin(nanome.AsyncPluginInstance):
         fixed_comp = updated_complexes[0]
         moving_comp_list = updated_complexes[1:]
         fixed_binding_site_residues = await self.get_binding_site_residues(fixed_comp, ligand_index, site_size)
-        
+
         # Select all atoms in the fixed binding site
         for atom in itertools.chain(*[res.atoms for res in fixed_binding_site_residues]):
             atom.selected = True
@@ -173,7 +173,7 @@ class SuperimposePlugin(nanome.AsyncPluginInstance):
             moving_comp.boxed = False
             moving_comp.set_surface_needs_redraw()
             comps_to_update.append(moving_comp)
-        
+
         self.update_structures_shallow(comps_to_update)
         self.update_structures_shallow(itertools.chain(*[comp.atoms for comp in comps_to_update]))
         # Due to a bug in nanome-core, if a complex is unlocked, we need to
@@ -209,6 +209,7 @@ class SuperimposePlugin(nanome.AsyncPluginInstance):
     def update_submit_btn_text(self, new_text):
         if getattr(self, 'menu', None):
             self.menu.update_submit_btn_text(new_text)
+
 
 def main():
     plugin_title = 'Superimpose Proteins'

--- a/plugin/menu.py
+++ b/plugin/menu.py
@@ -809,10 +809,11 @@ class MainMenu:
                 btns_to_update.append(btn)
         if btns_to_update:
             self.plugin.update_content(*btns_to_update)
-    
+
     def update_submit_btn_text(self, new_text):
         self.btn_submit.text.value.unusable = new_text
         self.plugin.update_content(self.btn_submit)
+
 
 class RMSDMenu(ui.Menu):
 

--- a/plugin/menu.py
+++ b/plugin/menu.py
@@ -192,12 +192,13 @@ class MainMenu:
                 if not all([fixed_comp_index, ligand_name, moving_comp_indices]):
                     msg = "Please select all complexes and ligand."
                     Logs.warning(msg)
+                    run_successful = False
                     self.plugin.send_notification(NotificationTypes.error, msg)
                 else:
                     Logs.message(f"Superimposing {moving_comp_count + 1} structures by {current_mode.name.lower()}, using {overlay_method.name.lower()}")
                     rmsd_results = await self.plugin.superimpose_by_binding_site(
                         fixed_comp_index, ligand_name, moving_comp_indices)
-            run_successful = True
+                    run_successful = True
         except Exception as e:
             rmsd_results = {}
             Logs.error("Error calculating Superposition.")

--- a/plugin/menu.py
+++ b/plugin/menu.py
@@ -187,10 +187,10 @@ class MainMenu:
                 Logs.message(f"Superimposing {moving_comp_count + 1} structures by {current_mode.name.lower()}, using {overlay_method.name.lower()}")
                 rmsd_results = await self.plugin.superimpose_by_chain(fixed_comp_index, fixed_chain, moving_comp_chain_list, overlay_method)
             elif current_mode == AlignmentModeEnum.BINDING_SITE:
-                ligand_name = self.get_binding_site_ligand()
+                ligand_index = self.get_binding_site_ligand()
                 moving_comp_indices = self.get_moving_comp_indices()
                 moving_comp_count = len(moving_comp_indices)
-                if not all([fixed_comp_index, ligand_name, moving_comp_indices]):
+                if not all([fixed_comp_index, ligand_index is not None, moving_comp_indices]):
                     msg = "Please select all complexes and ligand."
                     Logs.warning(msg)
                     run_successful = False
@@ -198,8 +198,13 @@ class MainMenu:
                 else:
                     Logs.message(f"Superimposing {moving_comp_count + 1} structures by {current_mode.name.lower()}, using {overlay_method.name.lower()}")
                     rmsd_results = await self.plugin.superimpose_by_binding_site(
+<<<<<<< Updated upstream
                         fixed_comp_index, ligand_name, moving_comp_indices)
                     run_successful = True
+=======
+                        fixed_comp_index, ligand_index, moving_comp_indices)
+            run_successful = True
+>>>>>>> Stashed changes
         except Exception as e:
             rmsd_results = {}
             Logs.error("Error calculating Superposition.")
@@ -279,10 +284,14 @@ class MainMenu:
             if not ln_btn_fixed:
                 continue
             btn_fixed = ln_btn_fixed.get_content()
+            ligand_index = None
             if btn_fixed.selected:
                 dd_ligands = item.find_node('dd_ligands').get_content()
-                selected_ddi = next((ddi for ddi in dd_ligands.items if ddi.selected), None)
-                return getattr(selected_ddi, 'name', '')
+                for i, ddi in enumerate(dd_ligands.items):
+                    if ddi.selected:
+                        ligand_index = i
+                        break
+                return ligand_index
 
     def get_fixed_chain(self):
         for item in self.ln_moving_comp_list.get_content().items:

--- a/plugin/menu.py
+++ b/plugin/menu.py
@@ -198,13 +198,8 @@ class MainMenu:
                 else:
                     Logs.message(f"Superimposing {moving_comp_count + 1} structures by {current_mode.name.lower()}, using {overlay_method.name.lower()}")
                     rmsd_results = await self.plugin.superimpose_by_binding_site(
-<<<<<<< Updated upstream
-                        fixed_comp_index, ligand_name, moving_comp_indices)
-                    run_successful = True
-=======
                         fixed_comp_index, ligand_index, moving_comp_indices)
-            run_successful = True
->>>>>>> Stashed changes
+                    run_successful = True
         except Exception as e:
             rmsd_results = {}
             Logs.error("Error calculating Superposition.")

--- a/plugin/menu.py
+++ b/plugin/menu.py
@@ -804,7 +804,10 @@ class MainMenu:
                 btns_to_update.append(btn)
         if btns_to_update:
             self.plugin.update_content(*btns_to_update)
-
+    
+    def update_submit_btn_text(self, new_text):
+        self.btn_submit.text.value.unusable = new_text
+        self.plugin.update_content(self.btn_submit)
 
 class RMSDMenu(ui.Menu):
 

--- a/plugin/menu.py
+++ b/plugin/menu.py
@@ -165,9 +165,10 @@ class MainMenu:
             overlay_method = OverlayMethodEnum.ALPHA_CARBONS_ONLY
         Logs.message("Submit button Pressed.")
 
-        self.ln_loading_bar.enabled = True
-        self.loading_bar.percentage = 0
-        self.plugin.update_node(self.ln_loading_bar)
+        if current_mode != AlignmentModeEnum.BINDING_SITE:
+            self.ln_loading_bar.enabled = True
+            self.loading_bar.percentage = 0
+            self.plugin.update_node(self.ln_loading_bar)
 
         start_time = time.time()
         rmsd_results = None

--- a/plugin/site_motif_client.py
+++ b/plugin/site_motif_client.py
@@ -10,8 +10,8 @@ from nanome.api.structure import Complex
 class SiteMotifClient:
 
     @staticmethod
-    def find_match(binding_site_pdb: str, pocket_pdbs: list):
-        """Finds the pocket that best matches provided binding site."""
+    def run(binding_site_pdb: str, pocket_pdbs: list, align_output_file: str):
+        """Runs SiteMotif and writes results to align_output_file."""
         with tempfile.TemporaryDirectory() as output_dir:
             sites_dir = tempfile.TemporaryDirectory(dir=output_dir)
             shutil.copy(binding_site_pdb, sites_dir.name)
@@ -21,7 +21,6 @@ class SiteMotifClient:
             pdb_size_filepath = site_motif.write_pdb_size(sites_dir.name, output_dir)
             script_path = f'{os.path.dirname(site_motif.__file__)}/pocket_matrix_mpi7.py'
             command = f"mpiexec -n 4 python {script_path} {sites_dir.name} {pairs_filepath} {pdb_size_filepath} {output_dir}"
-
             try:
                 subprocess.run(command.split(), timeout=60)
             except subprocess.TimeoutExpired:
@@ -29,41 +28,41 @@ class SiteMotifClient:
 
             align_output = f'{output_dir}/align_output.txt'
             sites_dir.cleanup()
+            shutil.copy(align_output, align_output_file)
             # Uncomment for debugging
-            # shutil.copy(align_output, './align_output.txt')
-            if not os.path.exists(align_output):
+            # shutil.copy(align_output, 'align_output.txt')
+            if not os.path.exists(align_output_file):
                 raise Exception('No align output found')
-            with open(align_output, 'r') as f:
-                lines = f.readlines()
-                if not lines:
-                    raise Exception("No lines found in align output")
 
-            # Find the alignment that contains the longest fragment match
-            max_paired_res = -1
-            residue_alignment = ''
-            pdb_1 = ''
-            pdb_2 = ''
-            for line in lines:
-                line_split = line.split('\t')
-                if line_split[0] == line_split[1]:
-                    continue
-                aligned_residues = line_split[-1].strip()
-                paired_residue_count = len(aligned_residues.split(' '))
-                if paired_residue_count > max_paired_res:
-                    max_paired_res = paired_residue_count
-                    pdb_1 = line_split[0]
-                    pdb_2 = line_split[1]
-                    residue_alignment = aligned_residues
-            Logs.message(f"Longest fragment match: {max_paired_res}")
-            # Replace pdb names with full paths
-            for pdb_file in [binding_site_pdb, *pocket_pdbs]:
-                if pdb_1 in pdb_file:
-                    pdb_1 = pdb_file
-                if pdb_2 in pdb_file:
-                    pdb_2 = pdb_file
-                if pdb_1 and pdb_2:
-                    break
-            return pdb_1, pdb_2, residue_alignment
+    @staticmethod
+    def find_match(comp_index: int, align_output_file: str):
+        """Finds the pocket that best matches provided binding site."""
+        # Find the alignment that contains the longest fragment match
+        max_paired_res = -1
+        residue_alignment = ''
+        pdb_1 = ''
+        pdb_2 = ''
+        lines = []
+        with open(align_output_file, 'r') as f:
+            lines = f.readlines()
+            if not lines:
+                raise Exception("No lines found in align output")
+
+        for line in lines:
+            line_split = line.split('\t')
+            if str(comp_index) not in line_split[0] and str(comp_index) not in line_split[1]:
+                continue
+            if line_split[0] == line_split[1]:
+                continue
+            aligned_residues = line_split[-1].strip()
+            paired_residue_count = len(aligned_residues.split(' '))
+            if paired_residue_count > max_paired_res:
+                max_paired_res = paired_residue_count
+                pdb_1 = line_split[0]
+                pdb_2 = line_split[1]
+                residue_alignment = aligned_residues
+        Logs.message(f"Longest fragment match: {max_paired_res}")
+        return pdb_1, pdb_2, residue_alignment
 
     @staticmethod
     def parse_residue_pairs(comp1: Complex, comp2: Complex, alignment: str):

--- a/plugin/superimpose_by_binding_site.py
+++ b/plugin/superimpose_by_binding_site.py
@@ -8,7 +8,7 @@ from .site_motif_client import SiteMotifClient
 from . import utils
 
 
-def superimpose_by_binding_site(fixed_comp, moving_comps, fixed_binding_site_comp):
+def superimpose_by_binding_site(fixed_comp, moving_comps, fixed_binding_site_comp, plugin_instance):
     fpocket_client = FPocketClient()
     sitemotif_client = SiteMotifClient()
     temp_dir = tempfile.TemporaryDirectory()
@@ -18,6 +18,7 @@ def superimpose_by_binding_site(fixed_comp, moving_comps, fixed_binding_site_com
     fixed_pdb = fixed_binding_site_pdb.name
 
     pocket_residue_pdbs = []
+    plugin_instance.update_submit_btn_text('Finding Pockets...')
     for moving_comp in moving_comps:
         fpocket_results = fpocket_client.run(moving_comp, temp_dir.name)
         pocket_pdbs = fpocket_client.get_pocket_pdb_files(fpocket_results)
@@ -25,6 +26,7 @@ def superimpose_by_binding_site(fixed_comp, moving_comps, fixed_binding_site_com
         pocket_residue_pdbs.extend(comp_residue_pdbs)
 
     align_output_file = os.path.join(temp_dir.name, 'align_output.txt')
+    plugin_instance.update_submit_btn_text('Aligning pockets...')
     sitemotif_client.run(fixed_pdb, pocket_residue_pdbs, align_output_file)
     output_data = {}
     for moving_comp in moving_comps:
@@ -46,20 +48,20 @@ def superimpose_by_binding_site(fixed_comp, moving_comps, fixed_binding_site_com
         else:
             superimposer.set_atoms(comp2_bp_atoms, comp1_bp_atoms)
         # Select all alpha carbons used in the superimpose
-        comp1_atoms_selected = 0
-        comp2_atoms_selected = 0
-        for atom in comp1.atoms:
-            atom.selected = atom in comp1_atoms
-            if atom.selected:
-                comp1_atoms_selected += 1
-                atom.atom_mode = enums.AtomRenderingMode.BallStick
-                atom.residue.ribboned = False
-        for atom in comp2.atoms:
-            atom.selected = atom in comp2_atoms
-            if atom.selected:
-                comp2_atoms_selected += 1
-                atom.atom_mode = enums.AtomRenderingMode.BallStick
-                atom.residue.ribboned = False
+        # comp1_atoms_selected = 0
+        # comp2_atoms_selected = 0
+        # for atom in comp1.atoms:
+        #     atom.selected = atom in comp1_atoms
+        #     if atom.selected:
+        #         comp1_atoms_selected += 1
+        #         atom.atom_mode = enums.AtomRenderingMode.BallStick
+        #         atom.residue.ribboned = False
+        # for atom in comp2.atoms:
+        #     atom.selected = atom in comp2_atoms
+        #     if atom.selected:
+        #         comp2_atoms_selected += 1
+        #         atom.atom_mode = enums.AtomRenderingMode.BallStick
+        #         atom.residue.ribboned = False
 
         rms = round(superimposer.rms, 2)
         Logs.debug(f"RMSD: {rms}")

--- a/plugin/superimpose_by_binding_site.py
+++ b/plugin/superimpose_by_binding_site.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 from Bio.PDB import Superimposer
 from nanome.util import enums, Logs
@@ -7,59 +8,66 @@ from .site_motif_client import SiteMotifClient
 from . import utils
 
 
-def superimpose_by_binding_site(fixed_comp, moving_comp, fixed_binding_site_comp):
+def superimpose_by_binding_site(fixed_comp, moving_comps, fixed_binding_site_comp):
     fpocket_client = FPocketClient()
     sitemotif_client = SiteMotifClient()
     temp_dir = tempfile.TemporaryDirectory()
 
     fixed_binding_site_pdb = tempfile.NamedTemporaryFile(dir=temp_dir.name, suffix='.pdb')
     fixed_binding_site_comp.io.to_pdb(path=fixed_binding_site_pdb.name)
-
-    fpocket_results = fpocket_client.run(moving_comp, temp_dir.name)
-    pocket_pdbs = fpocket_client.get_pocket_pdb_files(fpocket_results)
-    pocket_residue_pdbs = utils.clean_fpocket_pdbs(pocket_pdbs, moving_comp)
-
     fixed_pdb = fixed_binding_site_pdb.name
-    pdb1, pdb2, alignment = sitemotif_client.find_match(fixed_pdb, pocket_residue_pdbs)
-    if fixed_pdb == pdb1:
-        comp1 = fixed_comp
-        comp2 = moving_comp
-    else:
-        comp1 = moving_comp
-        comp2 = fixed_comp
 
-    # Get biopython representation of alpha carbon atoms, and pass to superimposer
-    comp1_atoms, comp2_atoms = sitemotif_client.parse_residue_pairs(comp1, comp2, alignment)
-    comp1_bp_atoms = utils.convert_atoms_to_biopython(comp1_atoms)
-    comp2_bp_atoms = utils.convert_atoms_to_biopython(comp2_atoms)
-    superimposer = Superimposer()
-    if comp1 == fixed_comp:
-        superimposer.set_atoms(comp1_bp_atoms, comp2_bp_atoms)
-    else:
-        superimposer.set_atoms(comp2_bp_atoms, comp1_bp_atoms)
-    # Select all alpha carbons used in the superimpose
-    comp1_atoms_selected = 0
-    comp2_atoms_selected = 0
-    for atom in comp1.atoms:
-        atom.selected = atom in comp1_atoms
-        if atom.selected:
-            comp1_atoms_selected += 1
-            atom.atom_mode = enums.AtomRenderingMode.BallStick
-            atom.residue.ribboned = False
-    for atom in comp2.atoms:
-        atom.selected = atom in comp2_atoms
-        if atom.selected:
-            comp2_atoms_selected += 1
-            atom.atom_mode = enums.AtomRenderingMode.BallStick
-            atom.residue.ribboned = False
+    pocket_residue_pdbs = []
+    for moving_comp in moving_comps:
+        fpocket_results = fpocket_client.run(moving_comp, temp_dir.name)
+        pocket_pdbs = fpocket_client.get_pocket_pdb_files(fpocket_results)
+        comp_residue_pdbs = utils.clean_fpocket_pdbs(pocket_pdbs, moving_comp)
+        pocket_residue_pdbs.extend(comp_residue_pdbs)
 
-    rms = round(superimposer.rms, 2)
-    Logs.debug(f"Comp1 atoms selected: {comp1_atoms_selected}")
-    Logs.debug(f"Comp2 atoms selected: {comp2_atoms_selected}")
-    Logs.debug(f"RMSD: {rms}")
-    paired_atom_count = len(comp1_atoms)
-    paired_residue_count = paired_atom_count
-    rmsd_results = utils.format_superimposer_data(superimposer, paired_residue_count, paired_atom_count)
-    transform_matrix = utils.create_transform_matrix(superimposer)
+    align_output_file = os.path.join(temp_dir.name, 'align_output.txt')
+    sitemotif_client.run(fixed_pdb, pocket_residue_pdbs, align_output_file)
+    output_data = {}
+    for moving_comp in moving_comps:
+        pdb1, _, alignment = sitemotif_client.find_match(moving_comp.index, align_output_file)
+        if os.path.basename(fixed_pdb) == pdb1:
+            comp1 = fixed_comp
+            comp2 = moving_comp
+        else:
+            comp1 = moving_comp
+            comp2 = fixed_comp
+
+        # Get biopython representation of alpha carbon atoms, and pass to superimposer
+        comp1_atoms, comp2_atoms = sitemotif_client.parse_residue_pairs(comp1, comp2, alignment)
+        comp1_bp_atoms = utils.convert_atoms_to_biopython(comp1_atoms)
+        comp2_bp_atoms = utils.convert_atoms_to_biopython(comp2_atoms)
+        superimposer = Superimposer()
+        if comp1 == fixed_comp:
+            superimposer.set_atoms(comp1_bp_atoms, comp2_bp_atoms)
+        else:
+            superimposer.set_atoms(comp2_bp_atoms, comp1_bp_atoms)
+        # Select all alpha carbons used in the superimpose
+        comp1_atoms_selected = 0
+        comp2_atoms_selected = 0
+        for atom in comp1.atoms:
+            atom.selected = atom in comp1_atoms
+            if atom.selected:
+                comp1_atoms_selected += 1
+                atom.atom_mode = enums.AtomRenderingMode.BallStick
+                atom.residue.ribboned = False
+        for atom in comp2.atoms:
+            atom.selected = atom in comp2_atoms
+            if atom.selected:
+                comp2_atoms_selected += 1
+                atom.atom_mode = enums.AtomRenderingMode.BallStick
+                atom.residue.ribboned = False
+
+        rms = round(superimposer.rms, 2)
+        Logs.debug(f"RMSD: {rms}")
+        paired_atom_count = len(comp1_atoms)
+        paired_residue_count = paired_atom_count
+        rmsd_results = utils.format_superimposer_data(superimposer, paired_residue_count, paired_atom_count)
+        transform_matrix = utils.create_transform_matrix(superimposer)
+        output_data[moving_comp.index] = (transform_matrix, rmsd_results)
+    fixed_binding_site_pdb.close()
     temp_dir.cleanup()
-    return transform_matrix, rmsd_results
+    return output_data

--- a/plugin/superimpose_by_binding_site.py
+++ b/plugin/superimpose_by_binding_site.py
@@ -69,9 +69,9 @@ async def superimpose_by_binding_site(fixed_comp, moving_comps, fixed_binding_si
         binding_site_comp = utils.extract_binding_site(moving_comp, binding_site_residues)
         binding_site_comp.position = moving_comp.position
         binding_site_comp.rotation = moving_comp.rotation
+        binding_site_comp.locked = True
         # Make sure the binding aligns with its original position.
         # ComplexUtils.align_to(binding_site_comp, moving_comp)
-
         binding_site_comps.append(binding_site_comp)
         
     temp_dir.cleanup()
@@ -84,5 +84,6 @@ async def superimpose_by_binding_site(fixed_comp, moving_comps, fixed_binding_si
         for comp_atom in new_bsc.atoms:
             new_position = transform_matrix * comp_atom.position
             comp_atom.position = new_position
+            new_bsc.boxed = False
     await plugin_instance.update_structures_deep(created_binding_site_comps)
     return output_data

--- a/plugin/superimpose_by_binding_site.py
+++ b/plugin/superimpose_by_binding_site.py
@@ -8,7 +8,7 @@ from .site_motif_client import SiteMotifClient
 from . import utils
 
 
-def superimpose_by_binding_site(fixed_comp, moving_comps, fixed_binding_site_comp, plugin_instance):
+async def superimpose_by_binding_site(fixed_comp, moving_comps, fixed_binding_site_comp, plugin_instance):
     fpocket_client = FPocketClient()
     sitemotif_client = SiteMotifClient()
     temp_dir = tempfile.TemporaryDirectory()

--- a/plugin/superimpose_by_binding_site.py
+++ b/plugin/superimpose_by_binding_site.py
@@ -8,6 +8,7 @@ from .fpocket_client import FPocketClient
 from .site_motif_client import SiteMotifClient
 from . import utils
 
+
 async def superimpose_by_binding_site(fixed_comp, moving_comps, fixed_binding_site_comp, plugin_instance):
     fpocket_client = FPocketClient()
     sitemotif_client = SiteMotifClient()
@@ -28,7 +29,7 @@ async def superimpose_by_binding_site(fixed_comp, moving_comps, fixed_binding_si
     align_output_file = os.path.join(temp_dir.name, 'align_output.txt')
     plugin_instance.update_submit_btn_text('Aligning Pockets...')
     sitemotif_client.run(fixed_pdb, pocket_residue_pdbs, align_output_file)
-    
+
     fixed_binding_site_pdb.close()
     output_data = {}
     binding_site_comps = []
@@ -69,7 +70,7 @@ async def superimpose_by_binding_site(fixed_comp, moving_comps, fixed_binding_si
         binding_site_comp.rotation = moving_comp.rotation
         binding_site_comp.locked = True
         binding_site_comps.append(binding_site_comp)
-        
+
     temp_dir.cleanup()
     created_binding_site_comps = await plugin_instance.add_to_workspace(binding_site_comps)
     for old_bsc, new_bsc, moving_comp in zip(binding_site_comps, created_binding_site_comps, moving_comps):

--- a/plugin/superimpose_by_chain.py
+++ b/plugin/superimpose_by_chain.py
@@ -7,6 +7,7 @@ from nanome.api.structure import Complex
 
 from . import utils
 
+
 __all__ = ["superimpose_by_chain"]
 
 

--- a/plugin/utils.py
+++ b/plugin/utils.py
@@ -184,7 +184,7 @@ def clean_fpocket_pdbs(fpocket_pdbs, comp: Complex):
         pocket_pdb = fpocket_pdbs[i]
         new_filename = f'{comp.index}_{os.path.basename(pocket_pdb)}'
         new_filepath = os.path.join(os.path.dirname(pocket_pdb), new_filename)
-        
+
         pocket_residues = set()
         # Add comp index to filename
         with open(pocket_pdb) as f:

--- a/plugin/utils.py
+++ b/plugin/utils.py
@@ -168,11 +168,14 @@ def extract_binding_site(comp, binding_site_residues):
 
     binding_site_residue_indices = [r.index for r in binding_site_residues]
     for ch in comp.chains:
-        reses_on_chain = [res for res in ch.residues if res.index in binding_site_residue_indices]
+        reses_on_chain = [res._deep_copy() for res in ch.residues if res.index in binding_site_residue_indices]
         if reses_on_chain:
             new_ch = Chain()
             new_ch.name = ch.name
+            for res in reses_on_chain:
+                res.bonds = []
             new_ch.residues = reses_on_chain
+
             new_mol.add_chain(new_ch)
     # Logs.debug(f'New comp residues: {len(list(new_comp.residues))}')
     return new_comp

--- a/plugin/utils.py
+++ b/plugin/utils.py
@@ -167,7 +167,6 @@ def extract_binding_site(comp, binding_site_residues):
     new_comp.index = -1
 
     binding_site_residue_indices = [r.index for r in binding_site_residues]
-    # Logs.debug(f'Binding site residues: {len(binding_site_residues)}')
     for ch in comp.chains:
         reses_on_chain = [res for res in ch.residues if res.index in binding_site_residue_indices]
         if reses_on_chain:

--- a/plugin/utils.py
+++ b/plugin/utils.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 import time
 
@@ -179,10 +180,15 @@ def extract_binding_site(comp, binding_site_residues):
 
 
 def clean_fpocket_pdbs(fpocket_pdbs, comp: Complex):
-    """Add full residue data to pdb files."""
+    """Add full residue data to pdb files, and add complex index to filename."""
     Logs.debug(f"Cleaning {len(fpocket_pdbs)} fpocket pdbs")
-    for i, pocket_pdb in enumerate(fpocket_pdbs):
+    for i in range(0, len(fpocket_pdbs)):
+        pocket_pdb = fpocket_pdbs[i]
+        new_filename = f'{comp.index}_{os.path.basename(pocket_pdb)}'
+        new_filepath = os.path.join(os.path.dirname(pocket_pdb), new_filename)
+        
         pocket_residues = set()
+        # Add comp index to filename
         with open(pocket_pdb) as f:
             for line in f:
                 if line.startswith('ATOM'):
@@ -192,7 +198,9 @@ def clean_fpocket_pdbs(fpocket_pdbs, comp: Complex):
                     residue = next(rez for rez in chain.residues if rez.serial == res_serial)
                     pocket_residues.add(residue)
         pocket_comp = extract_binding_site(comp, pocket_residues)
-        pocket_comp.io.to_pdb(path=pocket_pdb, options=PDBOPTIONS)
+        pocket_comp.io.to_pdb(path=new_filepath, options=PDBOPTIONS)
+        os.remove(pocket_pdb)
+        fpocket_pdbs[i] = new_filepath
     return fpocket_pdbs
 
 

--- a/plugin/utils.py
+++ b/plugin/utils.py
@@ -173,7 +173,6 @@ def extract_binding_site(comp, binding_site_residues):
             new_ch = Chain()
             new_ch.name = ch.name
             new_ch.residues = reses_on_chain
-
             new_mol.add_chain(new_ch)
     return new_comp
 

--- a/plugin/utils.py
+++ b/plugin/utils.py
@@ -206,7 +206,7 @@ def clean_fpocket_pdbs(fpocket_pdbs, comp: Complex):
 def convert_atoms_to_biopython(atom_list: list):
     """Converts atoms to biopython format."""
     parser = PDBParser(QUIET=True)
-    comp = atom_list[0].complex
+    comp = next(iter(atom_list)).complex
     comp_pdb = tempfile.NamedTemporaryFile(suffix=".pdb")
     comp.io.to_pdb(comp_pdb.name)
     struct1 = parser.get_structure(comp.full_name, comp_pdb.name)

--- a/plugin/utils.py
+++ b/plugin/utils.py
@@ -168,16 +168,13 @@ def extract_binding_site(comp, binding_site_residues):
 
     binding_site_residue_indices = [r.index for r in binding_site_residues]
     for ch in comp.chains:
-        reses_on_chain = [res._deep_copy() for res in ch.residues if res.index in binding_site_residue_indices]
+        reses_on_chain = [res for res in ch.residues if res.index in binding_site_residue_indices]
         if reses_on_chain:
             new_ch = Chain()
             new_ch.name = ch.name
-            for res in reses_on_chain:
-                res.bonds = []
             new_ch.residues = reses_on_chain
 
             new_mol.add_chain(new_ch)
-    # Logs.debug(f'New comp residues: {len(list(new_comp.residues))}')
     return new_comp
 
 


### PR DESCRIPTION
- Include all moving complexes in one site-motif run
- Create copy of extracted binding site for easier analysis
- Use ligand index instead of name